### PR TITLE
Add AGENTS instructions for running tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Instructions for Codex agents
+
+## Running tests
+
+This repository contains a prebuilt Python virtual environment in `.venv` with all required dependencies. Use this environment when running the tests so that imports resolve correctly and no network access is needed.
+
+To execute the test suite:
+
+```bash
+# Option 1: Use `uv run` which automatically uses `.venv`
+uv run pytest -q
+
+# Option 2: Activate the virtual environment directly
+source .venv/bin/activate
+pytest -q
+```
+
+Running tests outside of `.venv` or without `uv run` may fail due to missing packages. No additional `pip install` commands are necessary.


### PR DESCRIPTION
## Summary
- document how to run the tests using the prebuilt `.venv`

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683eb1f7abb08327887263025c92929c