### PR TITLE
Include VEBO events

### DIFF
--- a/src/csm_bot/rpc.py
+++ b/src/csm_bot/rpc.py
@@ -112,7 +112,11 @@ class Subscription:
             return
         logger.info(f"Processing blocks from %s to %s", start_block, current_block)
         batch_size = int(os.getenv("BLOCK_BATCH_SIZE", 10_000))
-        for contract in [os.getenv("CSM_ADDRESS"), os.getenv("FEE_DISTRIBUTOR_ADDRESS")]:
+        for contract in [
+            os.getenv("CSM_ADDRESS"),
+            os.getenv("FEE_DISTRIBUTOR_ADDRESS"),
+            os.getenv("VEBO_ADDRESS"),
+        ]:
             for batch_start in range(start_block, current_block + 1, batch_size):
                 batch_end = min(batch_start + batch_size - 1, current_block)
                 filter_params = FilterParams(


### PR DESCRIPTION
## Summary
- include VEBO contract when fetching historical logs

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68510240b9d483279e0be39885611ba6