### PR TITLE
feat: merge main and refine CSM v2 handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "python-dotenv",
     "tqdm>=4.66.5",
     "aiogram>=3.12.0",
+    "pytest-asyncio>=1.1.0",
+    "async-lru>=2.0.5",
 ]
 
 [build-system]

--- a/src/csm_bot/models.py
+++ b/src/csm_bot/models.py
@@ -39,3 +39,20 @@ class Event:
     def readable(self):
         args = ", ".join(f"{key}={value}" for key, value in self.args.items())
         return f"{self.event}({args})"
+
+class EventFilter:
+    """Base class for event filters."""
+    async def should_notify(self, event, node_operator_id: int, event_messages) -> bool:
+        """Return True if the node operator should receive notifications for this event."""
+        raise NotImplementedError
+
+    async def finalize(self):
+        """Optional cleanup method to be called when the filter is no longer needed."""
+        pass
+
+@dataclasses.dataclass
+class EventHandler:
+    """Dataclass to represent an event handler."""
+    event: str
+    handler: callable
+    filter: EventFilter = None

--- a/src/csm_bot/rpc.py
+++ b/src/csm_bot/rpc.py
@@ -97,7 +97,7 @@ class Subscription:
             )
             subs_fd = LogsSubscription(
                 address=os.getenv("FEE_DISTRIBUTOR_ADDRESS"),
-                topics=[fee_distributor.events.DistributionDataUpdated().topic],
+                topics=[fee_distributor.events.DistributionLogUpdated().topic],
                 handler=self._handle_event_log_subscription
             )
             subs_heads = NewHeadsSubscription(handler=self._handle_new_block_subscription)

--- a/src/csm_bot/texts.py
+++ b/src/csm_bot/texts.py
@@ -34,7 +34,7 @@ EVENT_DESCRIPTIONS = {
     "TotalSigningKeysCountChanged": "- 👀 New keys uploaded or removed",
     "ValidatorExitRequest": "- 🚨 One of the validators requested to exit",
     "PublicRelease": "- 🎉 Public release of CSM!",
-    "DistributionDataUpdated": "- 📈 New rewards distributed",
+    "DistributionLogUpdated": "- 📈 New rewards distributed",
     "TargetValidatorsCountChanged": "- 🚨 Target validators count changed",
     "Initialized": "- ✅ CSM v2 is here!",
 }
@@ -64,7 +64,7 @@ EVENT_LIST_TEXT = markdown(
     EVENT_DESCRIPTIONS["ValidatorExitRequest"], nl(1),
     EVENT_DESCRIPTIONS["WithdrawalSubmitted"], nl(),
     Bold("Common CSM Events for all the Node Operators:"), nl(1),
-    EVENT_DESCRIPTIONS["DistributionDataUpdated"], nl(1),
+    EVENT_DESCRIPTIONS["DistributionLogUpdated"], nl(1),
     EVENT_DESCRIPTIONS["PublicRelease"], nl(),
     EVENT_DESCRIPTIONS["Initialized"], nl(1),
 )
@@ -212,7 +212,7 @@ def public_release():
                     "Now everyone can join the CSM and upload any number of keys.")
 
 
-@RegisterEventMessage("DistributionDataUpdated")
+@RegisterEventMessage("DistributionLogUpdated")
 def distribution_data_updated():
     return markdown("📈 ", Bold("Rewards distributed!"), nl(),
                     "Follow the ", TextLink("CSM UI", url=os.getenv("CSM_UI_URL")),

--- a/src/tests/test_events.py
+++ b/src/tests/test_events.py
@@ -1,4 +1,7 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 from src.csm_bot.texts import target_validators_count_changed
+from hexbytes import HexBytes
 
 def test_limit_set_mode_1():
     result = target_validators_count_changed(0, 0, 1, 10)
@@ -54,3 +57,293 @@ def test_limit_unset_2():
     expected = ("🚨 *Target validators count changed*\n\n"
                 "The limit has been set to zero\. No keys will be requested to exit\.")
     assert result == expected
+
+# IPFS Distribution Filter Tests
+
+@pytest.mark.asyncio 
+@patch('aiohttp.ClientSession.get')
+@patch.dict('os.environ', {
+    'ETHERSCAN_URL': 'https://etherscan.io',
+    'BEACONCHAIN_URL': 'https://beaconcha.in',
+    'CSM_ADDRESS': '0x1234567890123456789012345678901234567890',
+    'ACCOUNTING_ADDRESS': '0x1234567890123456789012345678901234567890'
+})
+async def test_ipfs_distribution_filter_with_matching_operator(mock_get):
+    """Test that IPFSDistributionFilter returns True when node operator exists in IPFS data."""
+    from src.csm_bot.events import IPFSDistributionFilter
+    from src.csm_bot.models import Event
+    
+    # Mock IPFS response
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={
+        "operators": {
+            "123": {"some": "data"},
+            "456": {"other": "data"}
+        }
+    })
+    
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_context_manager.__aexit__ = AsyncMock(return_value=None)
+    mock_get.return_value = mock_context_manager
+    
+    # Create test event
+    event = Event(
+        event="DistributionLogUpdated",
+        args={"logCid": "QmTestHash123"},
+        block=123456,
+        tx=HexBytes("0x1234567890123456789012345678901234567890123456789012345678901234"),
+        address="0x1234567890123456789012345678901234567890",
+    )
+    
+    # Test the filter
+    filter_instance = IPFSDistributionFilter()
+    result = await filter_instance.should_notify(event, 123, None)
+    
+    assert result is True
+    mock_get.assert_called_once_with("https://ipfs.io/ipfs/QmTestHash123")
+
+
+@pytest.mark.asyncio
+@patch('aiohttp.ClientSession.get')
+@patch.dict('os.environ', {
+    'ETHERSCAN_URL': 'https://etherscan.io',
+    'BEACONCHAIN_URL': 'https://beaconcha.in',
+    'CSM_ADDRESS': '0x1234567890123456789012345678901234567890',
+    'ACCOUNTING_ADDRESS': '0x1234567890123456789012345678901234567890'
+})
+async def test_ipfs_distribution_filter_with_non_matching_operator(mock_get):
+    """Test that IPFSDistributionFilter returns False when node operator doesn't exist in IPFS data."""
+    from src.csm_bot.events import IPFSDistributionFilter
+    from src.csm_bot.models import Event
+    
+    # Mock IPFS response
+    mock_response = AsyncMock()
+    mock_response.status = 200 
+    mock_response.json = AsyncMock(return_value={
+        "operators": {
+            "123": {"some": "data"},
+            "456": {"other": "data"}
+        }
+    })
+    
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_context_manager.__aexit__ = AsyncMock(return_value=None)
+    mock_get.return_value = mock_context_manager
+    
+    # Create test event
+    event = Event(
+        event="DistributionLogUpdated",
+        args={"logCid": "QmTestHash123"},
+        block=123456,
+        tx=HexBytes("0x1234567890123456789012345678901234567890123456789012345678901234"),
+        address="0x1234567890123456789012345678901234567890",
+    )
+    
+    # Test the filter
+    filter_instance = IPFSDistributionFilter()
+    result = await filter_instance.should_notify(event, 999, None)  # Non-existing operator
+    
+    assert result is False
+    mock_get.assert_called_once_with("https://ipfs.io/ipfs/QmTestHash123")
+
+
+@pytest.mark.asyncio
+@patch('aiohttp.ClientSession.get')
+@patch.dict('os.environ', {
+    'ETHERSCAN_URL': 'https://etherscan.io',
+    'BEACONCHAIN_URL': 'https://beaconcha.in',
+    'CSM_ADDRESS': '0x1234567890123456789012345678901234567890',
+    'ACCOUNTING_ADDRESS': '0x1234567890123456789012345678901234567890'
+})
+async def test_ipfs_distribution_filter_caches_data(mock_get):
+    """Test that IPFSDistributionFilter caches data and doesn't fetch multiple times for same event."""
+    from src.csm_bot.events import IPFSDistributionFilter
+    from src.csm_bot.models import Event
+    
+    # Mock IPFS response
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={
+        "operators": {
+            "123": {"some": "data"},
+            "456": {"other": "data"}
+        }
+    })
+    
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_context_manager.__aexit__ = AsyncMock(return_value=None)
+    mock_get.return_value = mock_context_manager
+    
+    # Create test event
+    event = Event(
+        event="DistributionLogUpdated",
+        args={"logCid": "QmTestHash123"},
+        block=123456,
+        tx=HexBytes("0x1234567890123456789012345678901234567890123456789012345678901234"),
+        address="0x1234567890123456789012345678901234567890",
+    )
+    
+    # Test the filter multiple times with same event
+    filter_instance = IPFSDistributionFilter()
+    
+    result1 = await filter_instance.should_notify(event, 123, None)
+    result2 = await filter_instance.should_notify(event, 456, None)
+    result3 = await filter_instance.should_notify(event, 999, None)
+    
+    assert result1 is True
+    assert result2 is True
+    assert result3 is False
+    
+    # Should only fetch once despite multiple calls
+    assert mock_get.call_count == 1
+    mock_get.assert_called_with("https://ipfs.io/ipfs/QmTestHash123")
+
+
+@pytest.mark.asyncio
+@patch('aiohttp.ClientSession.get')
+@patch.dict('os.environ', {
+    'ETHERSCAN_URL': 'https://etherscan.io',
+    'BEACONCHAIN_URL': 'https://beaconcha.in',
+    'CSM_ADDRESS': '0x1234567890123456789012345678901234567890',
+    'ACCOUNTING_ADDRESS': '0x1234567890123456789012345678901234567890'
+})
+async def test_ipfs_distribution_filter_handles_http_error(mock_get):
+    """Test that IPFSDistributionFilter handles HTTP errors gracefully."""
+    from src.csm_bot.events import IPFSDistributionFilter
+    from src.csm_bot.models import Event
+    
+    # Mock HTTP error response
+    mock_response = AsyncMock()
+    mock_response.status = 404
+    
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_context_manager.__aexit__ = AsyncMock(return_value=None)
+    mock_get.return_value = mock_context_manager
+    
+    # Create test event
+    event = Event(
+        event="DistributionLogUpdated",
+        args={"logCid": "QmTestHash123"},
+        block=123456,
+        tx=HexBytes("0x1234567890123456789012345678901234567890123456789012345678901234"),
+        address="0x1234567890123456789012345678901234567890",
+    )
+    
+    # Test the filter
+    filter_instance = IPFSDistributionFilter()
+    result = await filter_instance.should_notify(event, 123, None)
+    
+    # Should return False when unable to fetch data
+    assert result is False
+
+
+@pytest.mark.asyncio
+@patch.dict('os.environ', {
+    'ETHERSCAN_URL': 'https://etherscan.io',
+    'BEACONCHAIN_URL': 'https://beaconcha.in',
+    'CSM_ADDRESS': '0x1234567890123456789012345678901234567890',
+    'ACCOUNTING_ADDRESS': '0x1234567890123456789012345678901234567890'
+})
+async def test_ipfs_distribution_filter_handles_missing_tree_cid():
+    """Test that IPFSDistributionFilter handles missing logCid gracefully."""
+    from src.csm_bot.events import IPFSDistributionFilter
+    from src.csm_bot.models import Event
+    
+    # Create test event without logCid
+    event = Event(
+        event="DistributionLogUpdated",
+        args={"someOtherField": "value"},  # No logCid
+        block=123456,
+        tx=HexBytes("0x1234567890123456789012345678901234567890123456789012345678901234"),
+        address="0x1234567890123456789012345678901234567890",
+    )
+    
+    # Test the filter
+    filter_instance = IPFSDistributionFilter()
+    result = await filter_instance.should_notify(event, 123, None)
+    
+    # Should return False when logCid is missing
+    assert result is False
+
+
+@pytest.mark.asyncio
+@patch('aiohttp.ClientSession.get')
+@patch.dict('os.environ', {
+    'ETHERSCAN_URL': 'https://etherscan.io',
+    'BEACONCHAIN_URL': 'https://beaconcha.in',
+    'CSM_ADDRESS': '0x1234567890123456789012345678901234567890',
+    'ACCOUNTING_ADDRESS': '0x1234567890123456789012345678901234567890'
+})
+async def test_ipfs_distribution_filter_handles_empty_operators(mock_get):
+    """Test that IPFSDistributionFilter handles empty operators object."""
+    from src.csm_bot.events import IPFSDistributionFilter
+    from src.csm_bot.models import Event
+    
+    # Mock IPFS response with empty operators
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={
+        "operators": {}
+    })
+    
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_context_manager.__aexit__ = AsyncMock(return_value=None)
+    mock_get.return_value = mock_context_manager
+    
+    # Create test event
+    event = Event(
+        event="DistributionLogUpdated",
+        args={"logCid": "QmTestHash123"},
+        block=123456,
+        tx=HexBytes("0x1234567890123456789012345678901234567890123456789012345678901234"),
+        address="0x1234567890123456789012345678901234567890",
+    )
+    
+    # Test the filter
+    filter_instance = IPFSDistributionFilter()
+    result = await filter_instance.should_notify(event, 123, None)
+    
+    assert result is False
+
+
+@pytest.mark.asyncio
+@patch('aiohttp.ClientSession.get')
+@patch.dict('os.environ', {
+    'ETHERSCAN_URL': 'https://etherscan.io',
+    'BEACONCHAIN_URL': 'https://beaconcha.in',
+    'CSM_ADDRESS': '0x1234567890123456789012345678901234567890',
+    'ACCOUNTING_ADDRESS': '0x1234567890123456789012345678901234567890'
+})
+async def test_ipfs_distribution_filter_handles_timeout(mock_get):
+    """Test that IPFSDistributionFilter handles timeout errors gracefully."""
+    from src.csm_bot.events import IPFSDistributionFilter
+    from src.csm_bot.models import Event
+    import asyncio
+    
+    # Mock timeout error
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError("Timeout"))
+    mock_context_manager.__aexit__ = AsyncMock(return_value=None)
+    mock_get.return_value = mock_context_manager
+    
+    # Create test event
+    event = Event(
+        event="DistributionLogUpdated",
+        args={"logCid": "QmTestHash123"},
+        block=123456,
+        tx=HexBytes("0x1234567890123456789012345678901234567890123456789012345678901234"),
+        address="0x1234567890123456789012345678901234567890",
+    )
+    
+    # Test the filter
+    filter_instance = IPFSDistributionFilter()
+    result = await filter_instance.should_notify(event, 123, None)
+    
+    # Should return False when timeout occurs
+    assert result is False

--- a/uv.lock
+++ b/uv.lock
@@ -145,6 +145,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-lru"
+version = "2.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/4d/71ec4d3939dc755264f680f6c2b4906423a304c3d18e96853f0a595dfe97/async_lru-2.0.5.tar.gz", hash = "sha256:481d52ccdd27275f42c43a928b4a50c3bfb2d67af4e78b170e3e0bb39c66e5bb", size = 10380, upload-time = "2025-03-16T17:25:36.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/49/d10027df9fce941cb8184e78a02857af36360d33e1721df81c5ed2179a1a/async_lru-2.0.5-py3-none-any.whl", hash = "sha256:ab95404d8d2605310d345932697371a5f40def0487c03d6d0ad9138de52c9943", size = 6069, upload-time = "2025-03-16T17:25:35.422Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "24.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -289,6 +298,8 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },
+    { name = "async-lru" },
+    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot", extra = ["job-queue", "rate-limiter"] },
     { name = "tqdm" },
@@ -303,6 +314,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiogram", specifier = ">=3.12.0" },
+    { name = "async-lru", specifier = ">=2.0.5" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot", extras = ["rate-limiter", "job-queue"], specifier = ">=21.4" },
     { name = "tqdm", specifier = ">=4.66.5" },
@@ -743,6 +756,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919, upload-time = "2024-12-01T12:54:25.98Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083, upload-time = "2024-12-01T12:54:19.735Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- resolve merge conflicts with main
- determine CSM version at each event block and use historical bond curve
- update tests for new Event address field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b0066869788327beb1d89e0ac33f3f