### PR TITLE
Add Harbor publish workflow for fork

### DIFF
--- a/.github/workflows/build-push-harbor.yml
+++ b/.github/workflows/build-push-harbor.yml
@@ -1,0 +1,61 @@
+name: Build and Push Harbor Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Upstream release tag to build from
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  APP: csm-sentinel
+  REGISTRY: harbor.dev.k8s-dev.org
+  REPOSITORY: team-csm
+  REGISTRY_USER: robot$team-csm-rw
+  SOURCE_REPOSITORY: skhomuti/csm-sentinel
+
+concurrency:
+  group: harbor-publish-${{ github.event.inputs.tag }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Resolve image tag
+        id: target
+        env:
+          SOURCE_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          echo "image_tag=${SOURCE_TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout upstream source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.SOURCE_REPOSITORY }}
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Harbor
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ secrets.HARBOR_ROBOT_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.APP }}:${{ steps.target.outputs.image_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Build Harbor images in the internal fork from an explicit upstream release tag, using the upstream source repository directly instead of mirroring tags into the fork. Configure the workflow for team-csm on harbor.dev.k8s-dev.org.
