### PR TITLE
fix: handle curated operator group names

### DIFF
--- a/abi/v3/MetaRegistry.json
+++ b/abi/v3/MetaRegistry.json
@@ -129,6 +129,11 @@
         "internalType": "struct IMetaRegistry.OperatorGroup",
         "components": [
           {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
             "name": "subNodeOperators",
             "type": "tuple[]",
             "internalType": "struct IMetaRegistry.SubNodeOperator[]",
@@ -299,6 +304,11 @@
         "type": "tuple",
         "internalType": "struct IMetaRegistry.OperatorGroup",
         "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
           {
             "name": "subNodeOperators",
             "type": "tuple[]",
@@ -768,6 +778,11 @@
         "internalType": "struct IMetaRegistry.OperatorGroup",
         "components": [
           {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
             "name": "subNodeOperators",
             "type": "tuple[]",
             "internalType": "struct IMetaRegistry.SubNodeOperator[]",
@@ -817,6 +832,11 @@
         "indexed": false,
         "internalType": "struct IMetaRegistry.OperatorGroup",
         "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
           {
             "name": "subNodeOperators",
             "type": "tuple[]",
@@ -1011,6 +1031,11 @@
   {
     "type": "error",
     "name": "InvalidOperatorGroupId",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidOperatorGroupName",
     "inputs": []
   },
   {

--- a/sentinel/modules/base_events.py
+++ b/sentinel/modules/base_events.py
@@ -107,9 +107,9 @@ class BaseModule(EventMessageEngineBase):
         previous_fee_splits = await self.accounting.functions.getFeeSplits(
             event.args["nodeOperatorId"]
         ).call(block_identifier=event.block - 1)
-        return template(
-            event.args["feeSplits"], previous_fee_splits
-        ) + await self.event_footer(event)
+        return template(event.args["feeSplits"], previous_fee_splits) + await self.event_footer(
+            event
+        )
 
     async def bond_debt_increased(self, event: Event):
         template = self._require_message_template(event.event)

--- a/sentinel/modules/curated/events.py
+++ b/sentinel/modules/curated/events.py
@@ -51,8 +51,13 @@ def assert_event_mappings() -> None:
     )
 
 
+def _operator_group_name(group_info) -> str | None:
+    name = read_field(group_info, "name", 0)
+    return name if isinstance(name, str) and name else None
+
+
 def _sub_node_operators(group_info):
-    return read_field(group_info, "subNodeOperators", 0)
+    return read_field(group_info, "subNodeOperators", 1)
 
 
 def _sub_node_operator_ids(group_info) -> set[int]:
@@ -168,9 +173,7 @@ class CuratedEventMessages(BaseModule):
                     weights[node_operator_id],
                     total_weighted_share,
                 ),
-                "label": await self._node_operator_label(
-                    node_operator_id, block
-                ),
+                "label": await self._node_operator_label(node_operator_id, block),
             }
             for operator, node_operator_id in zip(
                 sub_node_operators, node_operator_ids, strict=True
@@ -317,6 +320,7 @@ class CuratedEventMessages(BaseModule):
         message = template(
             event.args["groupId"],
             await self._sub_node_operator_allocations(group_info, event.block),
+            group_name=_operator_group_name(group_info),
         ) + await self.event_footer(event)
         return NotificationPlan(broadcast=message).with_broadcast_targets(operator_ids)
 
@@ -327,8 +331,32 @@ class CuratedEventMessages(BaseModule):
         previous_group = await self.meta_registry.functions.getOperatorGroup(group_id).call(
             block_identifier=event.block - 1
         )
+        current_group = event.args["groupInfo"]
+        previous_group_name = _operator_group_name(previous_group)
+        current_group_name = _operator_group_name(current_group)
         previous_shares = _sub_node_operator_shares(previous_group)
-        current_shares = _sub_node_operator_shares(event.args["groupInfo"])
+        current_shares = _sub_node_operator_shares(current_group)
+        changed_operator_ids = set(previous_shares) ^ set(current_shares)
+        changed_operator_ids.update(
+            node_operator_id
+            for node_operator_id in set(previous_shares) & set(current_shares)
+            if previous_shares[node_operator_id] != current_shares[node_operator_id]
+        )
+        is_renamed = previous_group_name != current_group_name
+        if not changed_operator_ids:
+            if not is_renamed:
+                return None
+            operator_ids = set(current_shares)
+            if not operator_ids:
+                return None
+            message = template(
+                group_id,
+                change_kind="renamed",
+                old_group_name=previous_group_name,
+                new_group_name=current_group_name,
+            ) + await self.event_footer(event)
+            return NotificationPlan(broadcast=message).with_broadcast_targets(operator_ids)
+
         previous_operators = {
             int(read_field(operator, "nodeOperatorId", 0)): operator
             for operator in await self._sub_node_operator_allocations(
@@ -337,44 +365,52 @@ class CuratedEventMessages(BaseModule):
         }
         current_operators = {
             int(read_field(operator, "nodeOperatorId", 0)): operator
-            for operator in await self._sub_node_operator_allocations(
-                event.args["groupInfo"], event.block
-            )
+            for operator in await self._sub_node_operator_allocations(current_group, event.block)
         }
-        changed_operator_ids = set(previous_shares) ^ set(current_shares)
-        changed_operator_ids.update(
-            node_operator_id
-            for node_operator_id in set(previous_shares) & set(current_shares)
-            if previous_shares[node_operator_id] != current_shares[node_operator_id]
-        )
-        if not changed_operator_ids:
-            return None
-
+        target_operator_ids = changed_operator_ids | (set(current_shares) if is_renamed else set())
         footer = await self.event_footer(event)
-        plan = NotificationPlan().with_broadcast_targets(changed_operator_ids)
-        for node_operator_id in changed_operator_ids:
-            node_operator_label = await self._node_operator_label(node_operator_id, event.block)
-            if node_operator_id not in previous_shares:
+        plan = NotificationPlan().with_broadcast_targets(target_operator_ids)
+        for node_operator_id in target_operator_ids:
+            if node_operator_id not in changed_operator_ids:
+                message = template(
+                    group_id,
+                    change_kind="renamed",
+                    old_group_name=previous_group_name,
+                    new_group_name=current_group_name,
+                )
+            elif node_operator_id not in previous_shares:
+                node_operator_label = await self._node_operator_label(node_operator_id, event.block)
                 message = template(
                     group_id,
                     node_operator_label,
                     "added",
                     new_operator=current_operators[node_operator_id],
+                    group_name=current_group_name,
+                    old_group_name=previous_group_name if is_renamed else None,
+                    new_group_name=current_group_name if is_renamed else None,
                 )
             elif node_operator_id not in current_shares:
+                node_operator_label = await self._node_operator_label(node_operator_id, event.block)
                 message = template(
                     group_id,
                     node_operator_label,
                     "removed",
                     old_operator=previous_operators[node_operator_id],
+                    group_name=current_group_name,
+                    old_group_name=previous_group_name if is_renamed else None,
+                    new_group_name=current_group_name if is_renamed else None,
                 )
             else:
+                node_operator_label = await self._node_operator_label(node_operator_id, event.block)
                 message = template(
                     group_id,
                     node_operator_label,
                     "changed",
                     old_operator=previous_operators[node_operator_id],
                     new_operator=current_operators[node_operator_id],
+                    group_name=current_group_name,
+                    old_group_name=previous_group_name if is_renamed else None,
+                    new_group_name=current_group_name if is_renamed else None,
                 )
             plan.add_node_operator_message(node_operator_id, f"{message}{footer}")
         return plan
@@ -391,6 +427,7 @@ class CuratedEventMessages(BaseModule):
         message = template(
             event.args["groupId"],
             await self._sub_node_operator_allocations(previous_group, event.block - 1),
+            group_name=_operator_group_name(previous_group),
         ) + await self.event_footer(event)
         return NotificationPlan(broadcast=message).with_broadcast_targets(operator_ids)
 

--- a/sentinel/modules/curated/texts.py
+++ b/sentinel/modules/curated/texts.py
@@ -969,9 +969,7 @@ def _operator_label(operator) -> str:
     return f"#{read_field(operator, 'nodeOperatorId', 0)}"
 
 
-def _operator_group_allocation_lines(
-    operator, prefix: str = ""
-) -> list:
+def _operator_group_allocation_lines(operator, prefix: str = "") -> list:
     weighted_share_label = "Weighted share" if not prefix else f"{prefix}weighted share"
     return [
         f"{weighted_share_label}: ",
@@ -980,14 +978,33 @@ def _operator_group_allocation_lines(
     ]
 
 
+def _operator_group_identity(
+    group_name: str | None = None,
+    old_group_name: str | None = None,
+    new_group_name: str | None = None,
+) -> str | None:
+    if old_group_name != new_group_name and (old_group_name or new_group_name):
+        return f"{old_group_name or '<empty>'} -> {new_group_name or '<empty>'}"
+    if group_name:
+        return group_name
+    return None
+
+
+def _operator_group_label(group_id, **kwargs) -> str:
+    identity = _operator_group_identity(**kwargs)
+    if identity is None:
+        return str(group_id)
+    return f"{group_id}: {identity}"
+
+
 @register_event_message("OperatorGroupCreated")
-def operator_group_created(group_id, sub_node_operators):
+def operator_group_created(group_id, sub_node_operators, group_name=None):
     return markdown(
         "ℹ️ ",
         Bold("Operator group created"),
         nl(),
-        "Group id: ",
-        Code(str(group_id)),
+        "Group: ",
+        Code(_operator_group_label(group_id, group_name=group_name)),
         nl(1),
         "Added Node Operators:",
         nl(1),
@@ -997,21 +1014,46 @@ def operator_group_created(group_id, sub_node_operators):
 
 @register_event_message("OperatorGroupUpdated")
 def operator_group_updated(
-    group_id, node_operator_label, change_kind, old_operator=None, new_operator=None
+    group_id,
+    node_operator_label=None,
+    change_kind=None,
+    old_operator=None,
+    new_operator=None,
+    group_name=None,
+    old_group_name=None,
+    new_group_name=None,
 ):
     title_prefix = "🚨 " if change_kind == "removed" else "ℹ️ "
     parts: list = [
         title_prefix,
         Bold("Operator group updated"),
         nl(),
-        "Group id: ",
-        Code(str(group_id)),
+        "Group: ",
+        Code(
+            _operator_group_label(
+                group_id,
+                group_name=group_name,
+                old_group_name=old_group_name,
+                new_group_name=new_group_name,
+            )
+        ),
         nl(),
-        "Node Operator: ",
-        Code(str(node_operator_label)),
-        nl(1),
     ]
+    if node_operator_label is not None:
+        parts.extend(
+            [
+                "Node Operator: ",
+                Code(str(node_operator_label)),
+                nl(1),
+            ]
+        )
     match change_kind:
+        case "renamed":
+            parts.extend(
+                [
+                    "Group name changed.",
+                ]
+            )
         case "added":
             parts.extend(
                 [
@@ -1050,13 +1092,13 @@ def operator_group_updated(
 
 
 @register_event_message("OperatorGroupCleared")
-def operator_group_cleared(group_id, sub_node_operators):
+def operator_group_cleared(group_id, sub_node_operators, group_name=None):
     return markdown(
         "🚨 ",
         Bold("Operator group cleared"),
         nl(),
-        "Group id: ",
-        Code(str(group_id)),
+        "Group: ",
+        Code(_operator_group_label(group_id, group_name=group_name)),
         nl(1),
         "Affected Node Operators:",
         nl(1),

--- a/tests/integration/test_curated_telegram_subscription.py
+++ b/tests/integration/test_curated_telegram_subscription.py
@@ -209,7 +209,7 @@ async def test_curated_process_blocks_operator_group_created(anvil_launcher):
         fork_block=2766235,
         expected_markdown=(
             "ℹ️ *Operator group created*\n\n"
-            "Group id: `1`\n"
+            "Group: `1`\n"
             "Added Node Operators:\n"
             "\\- \\#0 \\- Attestant \\(BVI\\) Limited\n"
             "  Weighted share: 100% \\(group share: 100%\\)\n"

--- a/tests/integration/test_curated_telegram_subscription.py
+++ b/tests/integration/test_curated_telegram_subscription.py
@@ -227,16 +227,8 @@ async def test_curated_process_blocks_operator_group_updated(anvil_launcher):
         fork_block=2805615,
         expected_markdown=None,
         expected_per_node={
-            "0": (
-                "Weighted share: `100% \\-\\> 50%`\n"
-                "\n"
-                "Group share: `100% \\-\\> 50%`"
-            ),
-            "1": (
-                "Weighted share: `0% \\-\\> 50%`\n"
-                "\n"
-                "Group share: `0% \\-\\> 50%`"
-            ),
+            "0": ("Weighted share: `100% \\-\\> 50%`\n\nGroup share: `100% \\-\\> 50%`"),
+            "1": ("Weighted share: `0% \\-\\> 50%`\n\nGroup share: `0% \\-\\> 50%`"),
         },
         anvil_launcher=anvil_launcher,
     )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -249,6 +249,49 @@ def test_curated_burn_and_lock_templates_render_eth_asset_amounts():
     assert "Compensated amount: `0\\.5 ETH`" in bond_lock_compensated("0.5 ether")
 
 
+def test_curated_operator_group_templates_render_compact_group_label():
+    from sentinel.modules.curated.texts import (
+        operator_group_cleared,
+        operator_group_created,
+        operator_group_updated,
+    )
+
+    sub_node_operators = [
+        {
+            "label": "#10 - Operator Ten",
+            "share": 10000,
+            "weightedShare": 10000,
+        }
+    ]
+
+    created = operator_group_created(7, sub_node_operators, group_name="New Group")
+    assert "Group: `7: New Group`" in created
+    assert "Group id:" not in created
+    assert "Group name:" not in created
+
+    cleared = operator_group_cleared(7, sub_node_operators, group_name="")
+    assert "Group: `7`" in cleared
+    assert "Group: `7:" not in cleared
+
+    renamed_from_empty = operator_group_updated(
+        7,
+        change_kind="renamed",
+        old_group_name=None,
+        new_group_name="New Group",
+    )
+    assert "Group: `7: <empty\\> \\-\\> New Group`" in renamed_from_empty
+    assert "Group name changed" in renamed_from_empty
+    assert "Node Operator:" not in renamed_from_empty
+
+    renamed_to_empty = operator_group_updated(
+        7,
+        change_kind="renamed",
+        old_group_name="Old Group",
+        new_group_name=None,
+    )
+    assert "Group: `7: Old Group \\-\\> <empty\\>`" in renamed_to_empty
+
+
 def test_validator_slashing_reported_template_renders_pubkey_link():
     message = validator_slashing_reported(
         "0x1234",
@@ -913,10 +956,11 @@ async def test_curated_operator_group_created_targets_all_added_sub_node_operato
         args={
             "groupId": 7,
             "groupInfo": {
+                "name": "Test Group",
                 "subNodeOperators": [
                     {"nodeOperatorId": 10, "share": 4},
                     {"nodeOperatorId": 11, "share": 1},
-                ]
+                ],
             },
         },
         block=123,
@@ -929,6 +973,7 @@ async def test_curated_operator_group_created_targets_all_added_sub_node_operato
     assert isinstance(plan, NotificationPlan)
     assert plan.broadcast_node_operator_ids == {"10", "11"}
     assert "Operator group created" in plan.broadcast
+    assert "Group: `7: Test Group`" in plan.broadcast
     assert "Added Node Operators" in plan.broadcast
     assert "Operator Ten" in plan.broadcast
     assert "Weighted share: 50% \\(group share: 0\\.04%\\)" in plan.broadcast
@@ -955,10 +1000,11 @@ async def test_curated_operator_group_updated_targets_only_changed_sub_node_oper
     _set_event_config()
     meta_registry = _FakeMetaRegistry(
         {
+            "name": "Test Group",
             "subNodeOperators": [
                 {"nodeOperatorId": 10, "share": 4},
                 {"nodeOperatorId": 11, "share": 1},
-            ]
+            ],
         },
         metadata_names={10: "Operator Ten", 11: "Operator Eleven", 12: "Operator Twelve"},
         operator_weights_by_block={
@@ -981,10 +1027,11 @@ async def test_curated_operator_group_updated_targets_only_changed_sub_node_oper
         args={
             "groupId": 7,
             "groupInfo": {
+                "name": "Test Group",
                 "subNodeOperators": [
                     {"nodeOperatorId": 10, "share": 5},
                     {"nodeOperatorId": 12, "share": 2},
-                ]
+                ],
             },
         },
         block=123,
@@ -1024,6 +1071,133 @@ async def test_curated_operator_group_updated_targets_only_changed_sub_node_oper
 
 
 @pytest.mark.asyncio
+async def test_curated_operator_group_updated_notifies_group_name_change():
+    from sentinel.models import Event
+    from sentinel.modules.curated.events import CuratedEventMessages
+    from sentinel.notifications import NotificationPlan
+
+    _set_event_config()
+    meta_registry = _FakeMetaRegistry(
+        {
+            "name": "Old Group",
+            "subNodeOperators": [
+                {"nodeOperatorId": 10, "share": 4},
+                {"nodeOperatorId": 11, "share": 1},
+            ],
+        },
+        metadata_names={10: "Operator Ten", 11: "Operator Eleven"},
+        operator_weights_by_block={123: {10: 1, 11: 4}},
+    )
+    adapter = _FakeCuratedAdapter(
+        contracts=SimpleNamespace(
+            module=object(),
+            accounting=object(),
+            parameters_registry=object(),
+            meta_registry=meta_registry,
+        ),
+        notifiable_events={"OperatorGroupUpdated"},
+    )
+    event_messages = CuratedEventMessages(adapter, distribution_log_fetcher=_FakeFetcher(result={}))
+    event = Event(
+        event="OperatorGroupUpdated",
+        args={
+            "groupId": 7,
+            "groupInfo": {
+                "name": "New Group",
+                "subNodeOperators": [
+                    {"nodeOperatorId": 10, "share": 4},
+                    {"nodeOperatorId": 11, "share": 1},
+                ],
+            },
+        },
+        block=123,
+        tx=HexBytes("0xdeadbeef"),
+        address="0x0000000000000000000000000000000000000000",
+    )
+
+    plan = await event_messages.get_notification_plan(event)
+
+    assert isinstance(plan, NotificationPlan)
+    assert meta_registry.group_ids == [7]
+    assert meta_registry.call.calls == [{"block_identifier": 122}]
+    assert plan.broadcast_node_operator_ids == {"10", "11"}
+    assert plan.per_node_operator == {}
+    assert "Operator group updated" in plan.broadcast
+    assert "Group: `7: Old Group \\-\\> New Group`" in plan.broadcast
+    assert "Group name changed" in plan.broadcast
+    assert "Node Operator:" not in plan.broadcast
+    assert meta_registry.operator_weight_ids == []
+
+
+@pytest.mark.asyncio
+async def test_curated_operator_group_updated_notifies_unchanged_operators_on_group_rename():
+    from sentinel.models import Event
+    from sentinel.modules.curated.events import CuratedEventMessages
+    from sentinel.notifications import NotificationPlan
+
+    _set_event_config()
+    meta_registry = _FakeMetaRegistry(
+        {
+            "name": "Old Group",
+            "subNodeOperators": [
+                {"nodeOperatorId": 10, "share": 4},
+                {"nodeOperatorId": 11, "share": 1},
+            ],
+        },
+        metadata_names={
+            10: "Operator Ten",
+            11: "Operator Eleven",
+            12: "Operator Twelve",
+        },
+        operator_weights_by_block={
+            122: {10: 1, 11: 4},
+            123: {10: 1, 11: 4, 12: 5},
+        },
+    )
+    adapter = _FakeCuratedAdapter(
+        contracts=SimpleNamespace(
+            module=object(),
+            accounting=object(),
+            parameters_registry=object(),
+            meta_registry=meta_registry,
+        ),
+        notifiable_events={"OperatorGroupUpdated"},
+    )
+    event_messages = CuratedEventMessages(adapter, distribution_log_fetcher=_FakeFetcher(result={}))
+    event = Event(
+        event="OperatorGroupUpdated",
+        args={
+            "groupId": 7,
+            "groupInfo": {
+                "name": "New Group",
+                "subNodeOperators": [
+                    {"nodeOperatorId": 10, "share": 4},
+                    {"nodeOperatorId": 11, "share": 1},
+                    {"nodeOperatorId": 12, "share": 2},
+                ],
+            },
+        },
+        block=123,
+        tx=HexBytes("0xdeadbeef"),
+        address="0x0000000000000000000000000000000000000000",
+    )
+
+    plan = await event_messages.get_notification_plan(event)
+
+    assert isinstance(plan, NotificationPlan)
+    assert plan.broadcast_node_operator_ids == {"10", "11", "12"}
+    assert set(plan.per_node_operator) == {"10", "11", "12"}
+    assert "Group: `7: Old Group \\-\\> New Group`" in plan.per_node_operator["10"]
+    assert "Group name changed" in plan.per_node_operator["10"]
+    assert "Node Operator:" not in plan.per_node_operator["10"]
+    assert "Group name changed" in plan.per_node_operator["11"]
+    assert "Node Operator:" not in plan.per_node_operator["11"]
+    assert "Node Operator added" in plan.per_node_operator["12"]
+    assert "Operator Twelve" in plan.per_node_operator["12"]
+    assert "Group: `7: Old Group \\-\\> New Group`" in plan.per_node_operator["12"]
+
+
+@pytest.mark.asyncio
 async def test_curated_operator_group_cleared_lists_all_affected_node_operators():
     from sentinel.models import Event
     from sentinel.modules.curated.events import CuratedEventMessages
@@ -1032,10 +1206,11 @@ async def test_curated_operator_group_cleared_lists_all_affected_node_operators(
     _set_event_config()
     meta_registry = _FakeMetaRegistry(
         {
+            "name": "Test Group",
             "subNodeOperators": [
                 {"nodeOperatorId": 10, "share": 4},
                 {"nodeOperatorId": 11, "share": 1},
-            ]
+            ],
         },
         metadata_names={10: "Operator Ten", 11: "Operator Eleven"},
         operator_weights_by_block={122: {10: 1, 11: 4}},
@@ -1065,6 +1240,7 @@ async def test_curated_operator_group_cleared_lists_all_affected_node_operators(
     assert meta_registry.call.calls == [{"block_identifier": 122}]
     assert plan.broadcast_node_operator_ids == {"10", "11"}
     assert "Operator group cleared" in plan.broadcast
+    assert "Group: `7: Test Group`" in plan.broadcast
     assert "Affected Node Operators" in plan.broadcast
     assert "Operator Ten" in plan.broadcast
     assert "Weighted share: 50% \\(group share: 0\\.04%\\)" in plan.broadcast


### PR DESCRIPTION
## Release label

Apply one release label before merging:

- `release:major` for breaking changes
- `release:minor` for backward-compatible features
- `release:patch` for fixes and internal changes that should roll into the next release

If no `release:*` label is applied, release preparation treats the PR as `release:patch`.
