### PR TITLE
fix(curated): clarify operator group rename text

### DIFF
--- a/sentinel/modules/curated/texts.py
+++ b/sentinel/modules/curated/texts.py
@@ -978,23 +978,28 @@ def _operator_group_allocation_lines(operator, prefix: str = "") -> list:
     ]
 
 
-def _operator_group_identity(
-    group_name: str | None = None,
+def _operator_group_label(group_id, group_name: str | None = None) -> str:
+    if not group_name:
+        return str(group_id)
+    return f"{group_id}: {group_name}"
+
+
+def _operator_group_name_change_parts(
     old_group_name: str | None = None,
     new_group_name: str | None = None,
-) -> str | None:
-    if old_group_name != new_group_name and (old_group_name or new_group_name):
-        return f"{old_group_name or '<empty>'} -> {new_group_name or '<empty>'}"
-    if group_name:
-        return group_name
-    return None
-
-
-def _operator_group_label(group_id, **kwargs) -> str:
-    identity = _operator_group_identity(**kwargs)
-    if identity is None:
-        return str(group_id)
-    return f"{group_id}: {identity}"
+) -> list:
+    if old_group_name == new_group_name or not (old_group_name or new_group_name):
+        return []
+    if old_group_name and new_group_name:
+        return [
+            "Group renamed: ",
+            Code(old_group_name),
+            " -> ",
+            Code(new_group_name),
+        ]
+    if new_group_name:
+        return ["Group name set: ", Code(new_group_name)]
+    return ["Group name cleared: ", Code(old_group_name)]
 
 
 @register_event_message("OperatorGroupCreated")
@@ -1024,6 +1029,10 @@ def operator_group_updated(
     new_group_name=None,
 ):
     title_prefix = "🚨 " if change_kind == "removed" else "ℹ️ "
+    group_name_change_parts = _operator_group_name_change_parts(
+        old_group_name=old_group_name,
+        new_group_name=new_group_name,
+    )
     parts: list = [
         title_prefix,
         Bold("Operator group updated"),
@@ -1032,13 +1041,17 @@ def operator_group_updated(
         Code(
             _operator_group_label(
                 group_id,
-                group_name=group_name,
-                old_group_name=old_group_name,
-                new_group_name=new_group_name,
+                group_name=None if group_name_change_parts else group_name,
             )
         ),
-        nl(),
+        nl(1),
     ]
+    if group_name_change_parts:
+        parts.extend(group_name_change_parts)
+        if node_operator_label is not None or change_kind != "renamed":
+            parts.append(nl())
+    else:
+        parts.append(nl(1))
     if node_operator_label is not None:
         parts.extend(
             [
@@ -1049,11 +1062,7 @@ def operator_group_updated(
         )
     match change_kind:
         case "renamed":
-            parts.extend(
-                [
-                    "Group name changed.",
-                ]
-            )
+            pass
         case "added":
             parts.extend(
                 [

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -279,8 +279,9 @@ def test_curated_operator_group_templates_render_compact_group_label():
         old_group_name=None,
         new_group_name="New Group",
     )
-    assert "Group: `7: <empty\\> \\-\\> New Group`" in renamed_from_empty
-    assert "Group name changed" in renamed_from_empty
+    assert "Group: `7`" in renamed_from_empty
+    assert "Group name set: `New Group`" in renamed_from_empty
+    assert "<empty" not in renamed_from_empty
     assert "Node Operator:" not in renamed_from_empty
 
     renamed_to_empty = operator_group_updated(
@@ -289,7 +290,17 @@ def test_curated_operator_group_templates_render_compact_group_label():
         old_group_name="Old Group",
         new_group_name=None,
     )
-    assert "Group: `7: Old Group \\-\\> <empty\\>`" in renamed_to_empty
+    assert "Group: `7`" in renamed_to_empty
+    assert "Group name cleared: `Old Group`" in renamed_to_empty
+
+    renamed = operator_group_updated(
+        7,
+        change_kind="renamed",
+        old_group_name="Old Group",
+        new_group_name="New Group",
+    )
+    assert "Group: `7`" in renamed
+    assert "Group renamed: `Old Group` \\-\\> `New Group`" in renamed
 
 
 def test_validator_slashing_reported_template_renders_pubkey_link():
@@ -1123,8 +1134,8 @@ async def test_curated_operator_group_updated_notifies_group_name_change():
     assert plan.broadcast_node_operator_ids == {"10", "11"}
     assert plan.per_node_operator == {}
     assert "Operator group updated" in plan.broadcast
-    assert "Group: `7: Old Group \\-\\> New Group`" in plan.broadcast
-    assert "Group name changed" in plan.broadcast
+    assert "Group: `7`" in plan.broadcast
+    assert "Group renamed: `Old Group` \\-\\> `New Group`" in plan.broadcast
     assert "Node Operator:" not in plan.broadcast
     assert meta_registry.operator_weight_ids == []
 
@@ -1187,14 +1198,15 @@ async def test_curated_operator_group_updated_notifies_unchanged_operators_on_gr
     assert isinstance(plan, NotificationPlan)
     assert plan.broadcast_node_operator_ids == {"10", "11", "12"}
     assert set(plan.per_node_operator) == {"10", "11", "12"}
-    assert "Group: `7: Old Group \\-\\> New Group`" in plan.per_node_operator["10"]
-    assert "Group name changed" in plan.per_node_operator["10"]
+    assert "Group: `7`" in plan.per_node_operator["10"]
+    assert "Group renamed: `Old Group` \\-\\> `New Group`" in plan.per_node_operator["10"]
     assert "Node Operator:" not in plan.per_node_operator["10"]
-    assert "Group name changed" in plan.per_node_operator["11"]
+    assert "Group renamed: `Old Group` \\-\\> `New Group`" in plan.per_node_operator["11"]
     assert "Node Operator:" not in plan.per_node_operator["11"]
     assert "Node Operator added" in plan.per_node_operator["12"]
     assert "Operator Twelve" in plan.per_node_operator["12"]
-    assert "Group: `7: Old Group \\-\\> New Group`" in plan.per_node_operator["12"]
+    assert "Group: `7`" in plan.per_node_operator["12"]
+    assert "Group renamed: `Old Group` \\-\\> `New Group`" in plan.per_node_operator["12"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Release label

Apply one release label before merging:

- `release:major` for breaking changes
- `release:minor` for backward-compatible features
- `release:patch` for fixes and internal changes that should roll into the next release

If no `release:*` label is applied, release preparation treats the PR as `release:patch`.
